### PR TITLE
Add a simple page transition fade-in, for ooooh factor

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,7 @@ import { Toaster } from 'solid-toast'
 import { Sidebar } from 'sidebar'
 import { AuthStateProvider } from 'auth-state-provider'
 import './app.css'
+import { PageTransition } from './page-transition-maker'
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -34,7 +35,7 @@ function RootLayout(props: ParentProps) {
 			<Suspense>
 				<Sidebar />
 				<div class="mx-auto w-full max-w-[1100px] px-[1%] py-20 @container">
-					{props.children}
+					<PageTransition>{props.children}</PageTransition>
 				</div>
 			</Suspense>
 		</div>

--- a/src/page-transition-maker.tsx
+++ b/src/page-transition-maker.tsx
@@ -1,0 +1,29 @@
+import { Component, createSignal, createEffect, onCleanup } from 'solid-js'
+import { useLocation } from '@solidjs/router'
+import { cn } from 'lib/utils'
+
+export const PageTransition: Component = (props: { children: Element }) => {
+	const [isVisible, setIsVisible] = createSignal(false)
+	const location = useLocation()
+	createEffect(() => {
+		setIsVisible(false)
+		// This will re-run whenever the pathname changes
+		const currentPath = location?.pathname
+		const timer = setTimeout(() => {
+			setIsVisible(true)
+		}, 200) // Small delay to ensure new content is ready
+
+		onCleanup(() => clearTimeout(timer))
+	})
+
+	return (
+		<div
+			class={cn(
+				'transition-opacity duration-300 ease-in',
+				isVisible() ? 'opacity-100' : 'invisible opacity-0'
+			)}
+		>
+			{props.children}
+		</div>
+	)
+}

--- a/todo.txt
+++ b/todo.txt
@@ -15,7 +15,7 @@
 - [x] 4. set up tailwind, daisy, base layout, theme
 - [x] 5. add routes for `/profile`, `/learn`, `/learn/[lang]`
     - and getting-started and /learn/new-language
-    - and layouts for single-form, auth guard, and app width
+    - and layouts for single-form, auth guard (stub), and app width
 - [x] 5. add sidebar with state / static menu
 
 
@@ -44,6 +44,7 @@
 - [x] any: add Error state
 - [ ] any: add global error boundary https://docs.solidjs.com/concepts/control-flow/error-boundary
 - [ ] any: add Pending state (consider suspense query?)
+- [x] any: add page/navigation transition manager
 - [x] any: make login a mutation
 - [ ] any: make signout a mutation
 - [ ] any: replace react-modal


### PR DESCRIPTION
I'm stashing this on a branch bc I'm not happy with the implementation.

1. It uses a setTimeout to wait 200ms before starting the transition
2. I would like to use a suspense boundary or a useSuspenseQuery -- but tanstack/solid-query doesn't seem to have suspense queries so further research will be required
3. A good solution will wait till the queryClient is "settled" and then will immediately begin the transitionk without any more or less delay
4. This approach was also sometimes causing runtime errors with what appeared to be a race condition loading the route in order to watch it for changes, and sometimes causing a double-blink where partially loaded content would come in and then disappear and then come in again